### PR TITLE
Add OAS definition

### DIFF
--- a/oas/openapi.yml
+++ b/oas/openapi.yml
@@ -1,0 +1,56 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Open API for SCITT
+  description: Identifier and Credentials APIs for DID.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://vendor.transparency.example
+
+tags:
+  - name: Discovery
+  - name: Identifiers
+  - name: Statements
+  - name: Receipts
+
+paths:
+  
+  /.well-known/jwt-issuer:
+    $ref: './resources/.well-known/jwt-issuer.yml'
+  /.well-known/jwks:
+    $ref: './resources/.well-known/jwks.yml'
+  /.well-known/did.json:
+    $ref: './resources/.well-known/did.json.yml'
+
+  /issuers/{identifier}:
+    $ref: './resources/issuers/issuers.yml'
+
+  /statements:
+    $ref: './resources/statements/statements.yml'
+
+  /receipts/{identifier}:
+    $ref: './resources/receipts/receipts.yml'
+
+  /feeds:
+    $ref: './resources/feeds/feeds.yml'
+    
+  /feeds/{identifier}:
+    $ref: './resources/feeds/feed.yml'
+
+
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            'issuers:resolve': Grants permission to resolve an issuer's controller document
+            'statements:register': Grants permission to register a signed statement
+            'receipts:resolve': Grants permission to resolve a receipt
+            'feeds:list': Grants permission to list feeds
+            'feeds:resolve': Grants permission to resolve a feed

--- a/oas/resources/.well-known/did.json.yml
+++ b/oas/resources/.well-known/did.json.yml
@@ -1,0 +1,15 @@
+summary: Controller Document
+get:
+  summary: Controller Document
+  operationId: getTransparencyServiceControllerDocument
+  tags:
+    - Discovery
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/ControllerDocument.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/.well-known/jwks.yml
+++ b/oas/resources/.well-known/jwks.yml
@@ -1,0 +1,15 @@
+summary: JSON Web Key Set
+get:
+  summary: JSON Web Key Set
+  operationId: getTransparencyServiceJsonWebKeySet
+  tags:
+    - Discovery
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/Jwks.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/.well-known/jwt-issuer.yml
+++ b/oas/resources/.well-known/jwt-issuer.yml
@@ -1,0 +1,15 @@
+summary: JWT Issuer Metadata
+get:
+  summary: JWT Issuer Metadata
+  operationId: getTransparencyServiceJwtIssuerMetadata
+  tags:
+    - Discovery
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/JwtIssuerMetadata.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/feeds/feed.yml
+++ b/oas/resources/feeds/feed.yml
@@ -1,0 +1,25 @@
+
+get:
+  summary: Resolve
+  operationId: resolveFeed
+  tags:
+    - Feeds
+  security:
+    - OAuth2:
+        - 'feeds:resolve'
+  parameters:
+    - name: identifier
+      in: path
+      required: true
+      example: "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie"
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/Feed.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/feeds/feeds.yml
+++ b/oas/resources/feeds/feeds.yml
@@ -1,0 +1,18 @@
+
+get:
+  summary: List
+  operationId: listFeeds
+  tags:
+    - Feeds
+  security:
+    - OAuth2:
+        - 'feeds:list'
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/Feeds.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/issuers/issuers.yml
+++ b/oas/resources/issuers/issuers.yml
@@ -1,0 +1,25 @@
+
+get:
+  summary: Issuer
+  operationId: resolveIssuer
+  tags:
+    - Identifiers
+  security:
+    - OAuth2:
+        - 'issuers:resolve'
+  parameters:
+    - name: identifier
+      in: path
+      required: true
+      example: "did:web:vendor.transparency.example"
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/ControllerDocument.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/receipts/receipts.yml
+++ b/oas/resources/receipts/receipts.yml
@@ -1,0 +1,24 @@
+get:
+  summary: Retrieve
+  operationId: resolveReceipt
+  tags:
+    - Receipts
+  security:
+    - OAuth2:
+        - 'receipts:resolve'
+  parameters:
+    - name: identifier
+      in: path
+      required: true
+      example: "urn:uuid:baaf45fc-5266-11ee-be56-0242ac120002"
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/Receipt.yml"
+    default:
+      $ref: "../../responses/UnexpectedError.yml"

--- a/oas/resources/statements/statements.yml
+++ b/oas/resources/statements/statements.yml
@@ -1,0 +1,23 @@
+post:
+  summary: Register
+  operationId: registerSignedStatement
+  tags:
+    - Statements
+  security:
+    - OAuth2:
+        - 'statements:register'
+  requestBody:
+    description: Parameters for registering a signed statement
+    content:
+      application/json:
+        schema:
+          $ref: ../../schemas/Statement.yml
+  responses:
+    "200":
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: ../../schemas/Receipt.yml
+    default:
+      $ref: ../../responses/UnexpectedError.yml

--- a/oas/responses/UnexpectedError.yml
+++ b/oas/responses/UnexpectedError.yml
@@ -1,0 +1,5 @@
+description: Unexpected Error
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/Error.yml'

--- a/oas/schemas/ControllerDocument.yml
+++ b/oas/schemas/ControllerDocument.yml
@@ -1,0 +1,32 @@
+title: Controller Document
+type: object
+properties:
+  id:
+    type: string
+    example: 'did:web:vendor.transparency.example'
+additionalProperties: True
+example:
+  {
+    "id": "did:web:vendor.transparency.example",
+    "verificationMethod": [
+    {
+      "id": "did:web:vendor.transparency.example#urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+      "type": "JsonWebKey",
+      "controller": "did:web:vendor.transparency.example",
+      "publicKeyJwk": {
+        "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+        "kty": "EC",
+        "crv": "P-384",
+        "alg": "ES384",
+        "x": "NbaI-0w2h8nUxN2mJnD_Ozq9q3E5KEuCg22p5WD0bW5g7u8izXOS0ANuQA7_xxG0",
+        "y": "HmWJgIq4tfkVQkpMYRgp7yQyI20t9R6_wDI9CqYzF1Hy5AKIxRRXeWJN4ZNHa10P"
+      }
+    }
+  ],
+  "assertionMethod": [
+    "did:web:vendor.transparency.example#urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+  ],
+  "authentication": [
+    "did:web:vendor.transparency.example#urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+  ]
+  }

--- a/oas/schemas/Error.yml
+++ b/oas/schemas/Error.yml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - type
+  - detail
+properties:
+  type:
+    type: string
+  detail:
+    type: string
+example: 
+  {
+    "type": "urn:ietf:params:scitt:error:badSignatureAlgorithm",
+    "detail": "The Statement was signed with an algorithm the server does not support"
+  }

--- a/oas/schemas/Feed.yml
+++ b/oas/schemas/Feed.yml
@@ -1,0 +1,29 @@
+title: SCITT Feed
+type: object
+properties:
+  items:
+    type: array
+    items:
+      type: object
+additionalProperties: True
+example:
+  {
+    "id": "https://vendor.transparency.example/feeds/purl/pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
+    "receipts": [
+      {
+        "id": "urn:uuid:14c30b3a-b63d-4cd6-b358-f97d07ae4f49",
+        "receipt": "0oREoQE4IqEZAUFWB-CUF5dlEOQ...GT8AcTB_yw",
+        "description": "SPDX Software Bill of Materials"
+      },
+      {
+        "id": "urn:uuid:2729213a-f7e7-4370-ae07-c1d79c9e406a",
+        "receipt": "0oREoQE4IqEZAUFWB-CUF5dlEOQ...GT8AcTB_yw",
+        "description": "NIST Vulnerability Disclosure Report"
+      },
+      {
+        "id": "urn:uuid:ced478aa-7cb5-4483-bccd-571dc03f5fe2",
+        "receipt": "0oREoQE4IqEZAUFWB-CUF5dlEOQ...GT8AcTB_yw",
+        "description": "Synk Vulnerability Details Report"
+      }
+    ]
+  }

--- a/oas/schemas/Feeds.yml
+++ b/oas/schemas/Feeds.yml
@@ -1,0 +1,25 @@
+title: SCITT Feeds
+type: object
+properties:
+  items:
+    type: array
+    items:
+      type: object
+additionalProperties: True
+example:
+  {
+    "items": [
+      {
+        "id": "https://vendor.transparency.example/feeds/cpe/cpe:2.3:a:mitre:caldera:2.0.0:*:*:*:*:*:*:*",
+        "description": "A NIST NVD CPE based feed. https://nvd.nist.gov/products/cpe"
+      },
+      {
+        "id": "https://vendor.transparency.example/feeds/purl/pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
+        "description": "A PURL based feed. https://github.com/package-url/purl-spec"
+      },
+      {
+        "id": "https://vendor.transparency.example/feeds/01/09520123456788/10/ABC1/21/12345",
+        "description": "A GS1 Digital Link based feed. https://www.gs1.org/standards/gs1-digital-link"
+      }
+    ]
+  }

--- a/oas/schemas/Jwks.yml
+++ b/oas/schemas/Jwks.yml
@@ -1,0 +1,22 @@
+title: JSON Web Key Set
+description: https://www.ietf.org/id/draft-terbu-sd-jwt-vc-02.html#section-5.2
+type: object
+properties:
+  keys:
+    type: array
+    items:
+      type: object
+additionalProperties: True
+example:
+  {
+    "keys":[
+        {
+        "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+        "kty": "EC",
+        "crv": "P-384",
+        "alg": "ES384",
+        "x": "NbaI-0w2h8nUxN2mJnD_Ozq9q3E5KEuCg22p5WD0bW5g7u8izXOS0ANuQA7_xxG0",
+        "y": "HmWJgIq4tfkVQkpMYRgp7yQyI20t9R6_wDI9CqYzF1Hy5AKIxRRXeWJN4ZNHa10P"
+      }
+    ]
+  }

--- a/oas/schemas/JwtIssuerMetadata.yml
+++ b/oas/schemas/JwtIssuerMetadata.yml
@@ -1,0 +1,16 @@
+title: JSON Web Token Issuer Metadata
+description: https://www.ietf.org/id/draft-terbu-sd-jwt-vc-02.html#section-5.2
+type: object
+properties:
+  issuer:
+    type: string
+    example: 'https://vendor.transparency.example'
+  jwks_uri:
+    type: string
+    example: 'https://vendor.transparency.example/.well-known/jwks'
+additionalProperties: True
+example:
+  {
+    "issuer":"https://vendor.transparency.example",
+    "jwks_uri":"https://vendor.transparency.example/.well-known/jwks"
+  }

--- a/oas/schemas/Receipt.yml
+++ b/oas/schemas/Receipt.yml
@@ -1,0 +1,16 @@
+title: SCITT Receipt
+type: object
+properties:
+  id:
+    type: string
+    example: 'urn:uuid:baaf45fc-5266-11ee-be56-0242ac120002'
+  receipt:
+    type: string
+    description: A base64url encoded scitt receipt (a cose sign 1 secured verifiable data structure inclusion proof)
+    example: '0oREoQE4IqnpfwTiObXFlg...FvstEiV3hBQnT8AcB_yw'
+additionalProperties: True
+example:
+  {
+    "id": "urn:uuid:baaf45fc-5266-11ee-be56-0242ac120002",
+    "receipt": "0oREoQE4IqEZAU2FWB-CUF5dlEOQD8R50rMiP-aPpbpscmVkYWN0YWJsZV8xWB-CUM7paeOrnOrWw3pLLIJ42rlscmVkYWN0YWJsZV8yWB-CUKwDX2bQDMJ-ohLklplvOv9scmVkYWN0YWJsZV8zWB-CUJjoVQIlZT-VVXHr3HIxHb1scmVkYWN0YWJsZV80WCCCUCN6-rWeBcd1JZwf-kDkHpuBbHJlZGFjdGFibGVfNNhAWPSlZ2FycmF5XzGCY2JhcqEY3lggGsE0IXy17qHjFK3BczKgTiZPEn-mV_vEB7hh3LvoAxtnYXJyYXlfMoIKgaEY3lggjbE4CtUU-yac3di1JqGx9tiM_xPapcMIHukTxXVPoVZnYXJyYXlfM4JjYmFyoRjeWCDTkIX3jxYcqL4cGN7Sn7IzsCbFT4BWWs084CGiACPQJ2dhcnJheV80ggqBoRjeWCAmVXfTfGTmQ3xEUWTxbeb9rNhRba2ajZfuOrXwCYIEjmdhcnJheV81ggqhGN5YIK2JxHL7cDimjDTLcRpuHs8dVk2URvJBtX-0L1r2gonEWGCBDUsC5I1sbmWeySg838I_5CoUdbJCnOOIiSnj_Hh_FTodL4Jg9sHiV4LnpfwTiObXFlgT6_9Fk6MUr-RZrWl5AuZWjDjqf3ejO_KivPFvstEiV3hBQn-REGT8AcTB_yw"
+  }

--- a/oas/schemas/Statement.yml
+++ b/oas/schemas/Statement.yml
@@ -1,0 +1,16 @@
+title: SCITT Statement
+type: object
+properties:
+  id:
+    type: string
+    example: 'urn:uuid:baaf45fc-5266-11ee-be56-0242ac120002'
+  statement:
+    type: string
+    description: A base64url encoded scitt statement (a cose sign 1, with 🔥 attached payload 🔥)
+    example: '0oREoQE4IqnpfwTiObXFlg...FvstEiV3hBQnT8AcB_yw'
+additionalProperties: True
+example:
+  {
+    "id": "urn:uuid:baaf45fc-5266-11ee-be56-0242ac120002",
+    "statement": "0oREoQE4IqEZAU2FWB-CUF5dlEOQD8R50rMiP-aPpbpscmVkYWN0YWJsZV8xWB-CUM7paeOrnOrWw3pLLIJ42rlscmVkYWN0YWJsZV8yWB-CUKwDX2bQDMJ-ohLklplvOv9scmVkYWN0YWJsZV8zWB-CUJjoVQIlZT-VVXHr3HIxHb1scmVkYWN0YWJsZV80WCCCUCN6-rWeBcd1JZwf-kDkHpuBbHJlZGFjdGFibGVfNNhAWPSlZ2FycmF5XzGCY2JhcqEY3lggGsE0IXy17qHjFK3BczKgTiZPEn-mV_vEB7hh3LvoAxtnYXJyYXlfMoIKgaEY3lggjbE4CtUU-yac3di1JqGx9tiM_xPapcMIHukTxXVPoVZnYXJyYXlfM4JjYmFyoRjeWCDTkIX3jxYcqL4cGN7Sn7IzsCbFT4BWWs084CGiACPQJ2dhcnJheV80ggqBoRjeWCAmVXfTfGTmQ3xEUWTxbeb9rNhRba2ajZfuOrXwCYIEjmdhcnJheV81ggqhGN5YIK2JxHL7cDimjDTLcRpuHs8dVk2URvJBtX-0L1r2gonEWGCBDUsC5I1sbmWeySg838I_5CoUdbJCnOOIiSnj_Hh_FTodL4Jg9sHiV4LnpfwTiObXFlgT6_9Fk6MUr-RZrWl5AuZWjDjqf3ejO_KivPFvstEiV3hBQn-REGT8AcTB_yw"
+  }


### PR DESCRIPTION
This pull request addresses some of the API issues we have discussed.

1. to leverages JSON instead of CBOR / COSE media types, this makes it easier for developers.
1. it defines the mandatory service identity parts for DIDs and JWTs / CWTs that are related to the transparency service
1. it updates the endpoints to match the latest language (statements, receipts, feeds, issuers)

The existing draft text is not compatible, but my hope is that the API definition is easier to review and iterate on, and we can adjust the draft text, when we feel things have solidified enough